### PR TITLE
Populate the PeanutChassis and CompChassis drive types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Coding style was moved [here](https://docs.google.com/document/d/1H2Lz66Hy7pmFxP
 
 To-Do:
 1. Finish PeanutChassis and test functionality
-1. Create a ProductionChassis and test
+1. ~~Create a CompetitionChassis~~ and test
 1. Create and test TeleOp
 1. Prototype Autonomous
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # FRC_2018
 The code for the 2018 FRC game, Power Up
 
-### Coding Style
-* Use curly braces {} on a new line for declarations and loops
-* Order imports in order from most local to most global
+Coding style was moved [here](https://docs.google.com/document/d/1H2Lz66Hy7pmFxPAm8whiRg6tWnOfCiWSvpctdTY3pqo/edit)
 
 To-Do:
 1. Finish PeanutChassis and test functionality

--- a/src/Robot.cpp
+++ b/src/Robot.cpp
@@ -3,6 +3,7 @@
 
 Robot::Robot()
 {
+	drive = new PeanutChassis();
 
 }
 
@@ -23,7 +24,7 @@ void Robot::AutonomousInit()
 
 void Robot::AutonomousPeriodic()
 {
-
+	drive->TankDrive(0.3, -0.3);
 }
 
 void Robot::TeleopInit()
@@ -33,7 +34,7 @@ void Robot::TeleopInit()
 
 void Robot::TeleopPeriodic()
 {
-
+	drive->ArcadeDrive(drive->getJoystickValue(1), drive->getJoystickValue(0));
 }
 
 

--- a/src/Robot.h
+++ b/src/Robot.h
@@ -1,8 +1,11 @@
 #ifndef SRC_ROBOT_H_
 #define SRC_ROBOT_H_
 
-// Order imports based on most global -> local
+// Order imports based on most local -> global
 
+#include <driveType/BaseDrive.hpp>
+#include "driveType/PeanutChassis.h"
+#include "driveType/CompChassis.h"
 #include "WPILib.h"
 
 class Robot : public frc::IterativeRobot
@@ -27,6 +30,8 @@ public:
 
 
 private:
+	BaseDrive *drive;
+
 
 };
 

--- a/src/driveType/BaseDrive.h
+++ b/src/driveType/BaseDrive.h
@@ -18,13 +18,16 @@ using namespace CTRE::Phoenix::MotorControl::CAN;
 class BaseDrive
 {
 public:
-	virtual ~BaseDrive();
+	virtual ~BaseDrive() = 0;
 
 	// ---- DIFFERENTIAL_DRIVE METHODS ----
 	virtual void ArcadeDrive(double xSpeed, double zRotation, bool squaredInputs = true) = 0;
 	virtual void CurvatureDrive(double xSpeed, double zRotation, bool isQuickTurn) = 0;
 	virtual void TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs = true) = 0;
 	// ---- END DIFFERENTIAL_DRIVE METHODS ----
+
+	virtual void driveStraight(double speed) = 0;
+	virtual double getJoystickValue(int axisNum) = 0;
 
 protected:
 //	// These ARRAYS will store the port mappings for the motor(s)

--- a/src/driveType/BaseDrive.h
+++ b/src/driveType/BaseDrive.h
@@ -1,25 +1,39 @@
 #ifndef SRC_DRIVETYPE_BASEDRIVE_H_
 #define SRC_DRIVETYPE_BASEDRIVE_H_
 
+#if true
+	#define CTRE ctre
+	#define Phoenix phoenix
+	#define MotorControl motorcontrol
+	#define CAN can
+#endif
+
 // Include statements from most local to most global
 
-#include "ctre/Phoenix/MotorControl/CAN/TalonSRX.h"
+#include "ctre/phoenix/MotorControl/CAN/TalonSRX.h"
 #include "WPILib.h"
 
-using namespace CTRE::MotorControl::CAN;
+using namespace CTRE::Phoenix::MotorControl::CAN;
 
 class BaseDrive
 {
 public:
+	virtual ~BaseDrive();
+
+	// ---- DIFFERENTIAL_DRIVE METHODS ----
+	virtual void ArcadeDrive(double xSpeed, double zRotation, bool squaredInputs = true) = 0;
+	virtual void CurvatureDrive(double xSpeed, double zRotation, bool isQuickTurn) = 0;
+	virtual void TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs = true) = 0;
+	// ---- END DIFFERENTIAL_DRIVE METHODS ----
 
 protected:
-	// These arrays will store the port mappings for the motor(s)
-	int *LEFT_MOTOR_PORTS; // Will act as an array in child classes
-	int *RIGHT_MOTOR_PORTS;
+//	// These ARRAYS will store the port mappings for the motor(s)
+//	const int *LEFT_MOTOR_PORTS; // Will act as an array in child classes
+//	const int *RIGHT_MOTOR_PORTS;
 
 	DifferentialDrive *drive;
-//	TalonSRX *leftTalons[]; // List of left, right motors
-//	TalonSRX *rightTalons[];
+//	std::vector<TalonSRX> leftTalons; // List of left, right motors
+//	std::vector<TalonSRX> rightTalons;
 
 	Joystick *joystick;
 

--- a/src/driveType/BaseDrive.hpp
+++ b/src/driveType/BaseDrive.hpp
@@ -18,7 +18,11 @@ using namespace CTRE::Phoenix::MotorControl::CAN;
 class BaseDrive
 {
 public:
-	virtual ~BaseDrive() = 0;
+	virtual ~BaseDrive()
+	{
+		delete drive;
+		delete joystick;
+	};
 
 	// ---- DIFFERENTIAL_DRIVE METHODS ----
 	virtual void ArcadeDrive(double xSpeed, double zRotation, bool squaredInputs = true) = 0;

--- a/src/driveType/BaseDrive.hpp
+++ b/src/driveType/BaseDrive.hpp
@@ -1,5 +1,5 @@
-#ifndef SRC_DRIVETYPE_BASEDRIVE_H_
-#define SRC_DRIVETYPE_BASEDRIVE_H_
+#ifndef SRC_DRIVETYPE_BASEDRIVE_HPP_
+#define SRC_DRIVETYPE_BASEDRIVE_HPP_
 
 #if true
 	#define CTRE ctre
@@ -27,7 +27,23 @@ public:
 	// ---- END DIFFERENTIAL_DRIVE METHODS ----
 
 	virtual void driveStraight(double speed) = 0;
-	virtual double getJoystickValue(int axisNum) = 0;
+
+	/**
+	 * This will return the value of the axis specified by the given index.
+	 * The axis indices start at 0.
+	 *
+	 * @param axisNum
+	 * the index of the desired axis value (0: twist, 1: x, 2: y)
+	 *
+	 * @return
+	 * A double value from -1.0 to +1.0 according to the joystick's position
+	 * and the requested axis.
+	 */
+	virtual double getJoystickValue(int axisNum)
+	{
+		// TODO: Verify the axis mappings (what is 0, 1, 2, etc.?)
+		return joystick->GetRawAxis(axisNum);
+	}
 
 protected:
 //	// These ARRAYS will store the port mappings for the motor(s)
@@ -45,4 +61,4 @@ private:
 
 };
 
-#endif /* SRC_DRIVETYPE_BASEDRIVE_H_ */
+#endif /* SRC_DRIVETYPE_BASEDRIVE_HPP_ */

--- a/src/driveType/CompChassis.cpp
+++ b/src/driveType/CompChassis.cpp
@@ -96,4 +96,9 @@ void CompChassis::driveStraight(double speed)
 	TankDrive(speed + leftBias, speed + rightBias);
 }
 
+/*
+ * These methods will use the default functionality defined in BaseDrive.hpp:
+ *
+ * double PeanutChassis::getJoystickValue(int axisNum);
+ */
 

--- a/src/driveType/CompChassis.cpp
+++ b/src/driveType/CompChassis.cpp
@@ -83,3 +83,17 @@ void CompChassis::TankDrive(double leftSpeed, double rightSpeed, bool squaredInp
 	drive->TankDrive(leftSpeed, rightSpeed, squaredInputs);
 }
 
+/**
+ * Attempt to drive in a straight line using the pre-defined bias variables.
+ * This method could be used to conduct an automated test of the robot to help
+ * determine the ideal bias values for a completely straight path.
+ *
+ * @param speed
+ * the speed that the robot should drive forward at
+ */
+void CompChassis::driveStraight(double speed)
+{
+	TankDrive(speed + leftBias, speed + rightBias);
+}
+
+

--- a/src/driveType/CompChassis.cpp
+++ b/src/driveType/CompChassis.cpp
@@ -19,12 +19,6 @@ CompChassis::~CompChassis()
 	delete rightTalonMaster;
 }
 
-BaseDrive::~BaseDrive()
-{
-	delete drive;
-	delete joystick;
-}
-
 /**
  * Arcade drive method for differential drive platform. The calculated values
  * will be squared to decrease sensitivity at low speeds. This method

--- a/src/driveType/CompChassis.cpp
+++ b/src/driveType/CompChassis.cpp
@@ -1,0 +1,85 @@
+#include <driveType/CompChassis.h>
+#include "WPILib.h"
+
+CompChassis::CompChassis()
+{
+	leftTalonMaster = new WPI_TalonSRX(0);
+	rightTalonMaster = new WPI_TalonSRX(1);
+
+	drive = new DifferentialDrive(*leftTalonMaster, *rightTalonMaster);
+
+	joystick = new Joystick(0);
+
+}
+
+CompChassis::~CompChassis()
+{
+	// De-allocate pointers
+	delete leftTalonMaster;
+	delete rightTalonMaster;
+}
+
+BaseDrive::~BaseDrive()
+{
+	delete drive;
+	delete joystick;
+}
+
+/**
+ * Arcade drive method for differential drive platform. The calculated values
+ * will be squared to decrease sensitivity at low speeds. This method
+ * will use the motors and configurations required by the Competition Chassis.
+ *
+ * @param xSpeed
+ * the robot's speed along the X axis [-1.0..1.0]. Forward is positive.
+ * @param zRotation
+ * the robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is positive.
+ * @param squaredInputs
+ * default value is true, which will help limit sensitivity at slow speeds.
+ */
+void CompChassis::ArcadeDrive(double xSpeed, double zRotation, bool squaredInputs)
+{
+	drive->ArcadeDrive(xSpeed, zRotation, squaredInputs);
+}
+
+/**
+ * The rotation argument controls the curvature of the robot's path rather
+ * than its rate of heading change. This makes the robot more controllable
+ * at high speeds. Also handles the robot's quick turn functionality
+ * - "quick turn" overrides constant-curvature turning for turn-in-place
+ * maneuvers. This will use the configuration for the Competition Chassis.
+ *
+ * The main difference between this method and ArcadeDrive is that the
+ * zRotation equals the heading of the robot in this method; in ArcadeDrive,
+ * zRotation specifies how much the robot will turn.
+ *
+ * @param xSpeed
+ * the robot's speed along the X axis [-1.0..1.0]. Forward is positive.
+ * @param zRotation
+ * the robot's heading around the Z axis [-1.0..1.0]. Clockwise is positive.
+ * @param isQuickTurn
+ * if set, overrides constant-curvature turning for turn-in-place maneuvers.
+ *
+ */
+void CompChassis::CurvatureDrive(double xSpeed, double zRotation, bool isQuickTurn)
+{
+	drive->CurvatureDrive(xSpeed, zRotation, isQuickTurn);
+}
+
+/**
+ * Drive that explicitly takes the power of the left and right sides of the
+ * robot. squaredInputs will help reduce sensitivity if set to true. This
+ * method will use the configuration for the Competition Chassis.
+ *
+ * @param leftSpeed
+ * the speed of the left side of the robot
+ * @param rightSpeed
+ * the speed of the right side of the robot
+ * @param squredInputs
+ * defalut value is true. This will control how sensitive the robot is
+ */
+void CompChassis::TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs)
+{
+	drive->TankDrive(leftSpeed, rightSpeed, squaredInputs);
+}
+

--- a/src/driveType/CompChassis.h
+++ b/src/driveType/CompChassis.h
@@ -1,0 +1,32 @@
+#ifndef SRC_DRIVETYPE_COMPCHASSIS_H_
+#define SRC_DRIVETYPE_COMPCHASSIS_H_
+
+#include "BaseDrive.h"
+//#include "ctre/phoenix/MotorControl/CAN/TalonSRX.h"
+#include "ctre/Phoenix.h"
+
+
+using namespace CTRE::Phoenix::MotorControl::CAN;
+
+class CompChassis : public BaseDrive
+{
+public:
+	CompChassis();
+	virtual ~CompChassis();
+
+	// Override DifferentialDrive methods from the base drive class
+	// ---- DIFFERENTIAL_DRIVE METHODS ----
+	void ArcadeDrive(double xSpeed, double zRotation, bool squaredInputs = true) override;
+	void CurvatureDrive(double xSpeed, double zRotation, bool isQuickTurn) override;
+	void TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs = true) override;
+	// ---- END DIFFERENTIAL_DRIVE METHODS ----
+
+
+private:
+	// Probably have multiple motors, so declare master / slaves here
+	WPI_TalonSRX *leftTalonMaster;
+	WPI_TalonSRX *rightTalonMaster;
+
+};
+
+#endif /* SRC_DRIVETYPE_COMPCHASSIS_H_ */

--- a/src/driveType/CompChassis.h
+++ b/src/driveType/CompChassis.h
@@ -1,8 +1,7 @@
 #ifndef SRC_DRIVETYPE_COMPCHASSIS_H_
 #define SRC_DRIVETYPE_COMPCHASSIS_H_
 
-#include "BaseDrive.h"
-//#include "ctre/phoenix/MotorControl/CAN/TalonSRX.h"
+#include <driveType/BaseDrive.hpp>
 #include "ctre/Phoenix.h"
 
 
@@ -21,7 +20,7 @@ public:
 	void TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs = true) override;
 	// ---- END DIFFERENTIAL_DRIVE METHODS ----
 
-	void driveStraight(double speed);
+	void driveStraight(double speed) override;
 
 private:
 	// Probably have multiple motors, so declare master / slaves here

--- a/src/driveType/CompChassis.h
+++ b/src/driveType/CompChassis.h
@@ -21,11 +21,15 @@ public:
 	void TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs = true) override;
 	// ---- END DIFFERENTIAL_DRIVE METHODS ----
 
+	void driveStraight(double speed);
 
 private:
 	// Probably have multiple motors, so declare master / slaves here
 	WPI_TalonSRX *leftTalonMaster;
 	WPI_TalonSRX *rightTalonMaster;
+
+	double leftBias = 0.0; // Bias used to drive straight
+	double rightBias = 0.0;
 
 };
 

--- a/src/driveType/PeanutChassis.cpp
+++ b/src/driveType/PeanutChassis.cpp
@@ -96,3 +96,9 @@ void PeanutChassis::driveStraight(double speed)
 	TankDrive(speed + leftBias, speed + rightBias);
 }
 
+/*
+ * These methods will use the default functionality defined in BaseDrive.hpp:
+ *
+ * double PeanutChassis::getJoystickValue(int axisNum);
+ */
+

--- a/src/driveType/PeanutChassis.cpp
+++ b/src/driveType/PeanutChassis.cpp
@@ -19,13 +19,6 @@ PeanutChassis::~PeanutChassis()
 	delete rightTalon;
 }
 
-// Need to override the deconstructor
-BaseDrive::~BaseDrive()
-{
-	delete drive;
-	delete joystick;
-}
-
 /**
  * Arcade drive method for differential drive platform. The calculated values
  * will be squared to decrease sensitivity at low speeds. This method

--- a/src/driveType/PeanutChassis.cpp
+++ b/src/driveType/PeanutChassis.cpp
@@ -83,3 +83,16 @@ void PeanutChassis::TankDrive(double leftSpeed, double rightSpeed, bool squaredI
 	drive->TankDrive(leftSpeed, rightSpeed, squaredInputs);
 }
 
+/**
+ * Attempt to drive in a straight line using the pre-defined bias variables.
+ * This method could be used to conduct an automated test of the robot to help
+ * determine the ideal bias values for a completely straight path.
+ *
+ * @param speed
+ * the speed that the robot should drive forward at
+ */
+void PeanutChassis::driveStraight(double speed)
+{
+	TankDrive(speed + leftBias, speed + rightBias);
+}
+

--- a/src/driveType/PeanutChassis.cpp
+++ b/src/driveType/PeanutChassis.cpp
@@ -1,24 +1,85 @@
-#include <driveType/PeanutChassis.h>
-
-
+#include "driveType/PeanutChassis.h"
+#include "WPILib.h"
 
 PeanutChassis::PeanutChassis()
 {
+	leftTalon = new WPI_TalonSRX(0);
+	rightTalon = new WPI_TalonSRX(1);
 	
-	LEFT_MOTOR_PORTS = new int[1];
-	RIGHT_MOTOR_PORTS = new int[1];
+//	drive = new DifferentialDrive(leftTalon->GetWPILIB_SpeedController(), rightTalon->GetWPILIB_SpeedController());
+	drive = new DifferentialDrive(*leftTalon, *rightTalon);
 
-	// TODO: Make sure sizeof returns the correct value
-	//leftTalons
-	for(int l = 0; l < sizeof(LEFT_MOTOR_PORTS); l++)
-	{
-
-	}
-
+	joystick = new Joystick(0);
 }
 
 PeanutChassis::~PeanutChassis()
 {
+	// De-reference pointers
+	delete leftTalon;
+	delete rightTalon;
+}
 
+// Need to override the deconstructor
+BaseDrive::~BaseDrive()
+{
+	delete drive;
+	delete joystick;
+}
+
+/**
+ * Arcade drive method for differential drive platform. The calculated values
+ * will be squared to decrease sensitivity at low speeds. This method
+ * will use the motors and configurations required by the Peanut Chassis.
+ *
+ * @param xSpeed
+ * the robot's speed along the X axis [-1.0..1.0]. Forward is positive.
+ * @param zRotation
+ * the robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is positive.
+ * @param squaredInputs
+ * default value is true, which will help limit sensitivity at slow speeds.
+ */
+void PeanutChassis::ArcadeDrive(double xSpeed, double zRotation, bool squaredInputs)
+{
+	drive->ArcadeDrive(xSpeed, zRotation, squaredInputs);
+}
+
+/**
+ * The rotation argument controls the curvature of the robot's path rather
+ * than its rate of heading change. This makes the robot more controllable
+ * at high speeds. Also handles the robot's quick turn functionality
+ * - "quick turn" overrides constant-curvature turning for turn-in-place
+ * maneuvers.
+ *
+ * The main difference between this method and ArcadeDrive is that the
+ * zRotation equals the heading of the robot in this method; in ArcadeDrive,
+ * zRotation specifies how much the robot will turn.
+ *
+ * @param xSpeed
+ * the robot's speed along the X axis [-1.0..1.0]. Forward is positive.
+ * @param zRotation
+ * the robot's heading around the Z axis [-1.0..1.0]. Clockwise is positive.
+ * @param isQuickTurn
+ * if set, overrides constant-curvature turning for turn-in-place maneuvers.
+ *
+ */
+void PeanutChassis::CurvatureDrive(double xSpeed, double zRotation, bool isQuickTurn)
+{
+	drive->CurvatureDrive(xSpeed, zRotation, isQuickTurn);
+}
+
+/**
+ * Drive that explicitly takes the power of the left and right sides of the
+ * robot. squaredInputs will help reduce sensitivity if set to true.
+ *
+ * @param leftSpeed
+ * the speed of the left side of the robot
+ * @param rightSpeed
+ * the speed of the right side of the robot
+ * @param squredInputs
+ * defalut value is true. This will control how sensitive the robot is
+ */
+void PeanutChassis::TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs)
+{
+	drive->TankDrive(leftSpeed, rightSpeed, squaredInputs);
 }
 

--- a/src/driveType/PeanutChassis.h
+++ b/src/driveType/PeanutChassis.h
@@ -21,10 +21,14 @@ public:
 	void TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs = true) override;
 	// ---- END DIFFERENTIAL_DRIVE METHODS ----
 
+	void driveStraight(double speed);
 
 private:
 	WPI_TalonSRX *leftTalon;
 	WPI_TalonSRX *rightTalon;
+
+	double leftBias = 0.0; // Used to drive straight. Pre-defined and tested
+	double rightBias = 0.0;
 
 };
 

--- a/src/driveType/PeanutChassis.h
+++ b/src/driveType/PeanutChassis.h
@@ -1,8 +1,7 @@
 #ifndef SRC_DRIVETYPE_PEANUTCHASSIS_H_
 #define SRC_DRIVETYPE_PEANUTCHASSIS_H_
 
-#include "BaseDrive.h"
-//#include "ctre/phoenix/MotorControl/CAN/TalonSRX.h"
+#include <driveType/BaseDrive.hpp>
 #include "ctre/Phoenix.h"
 
 
@@ -21,12 +20,14 @@ public:
 	void TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs = true) override;
 	// ---- END DIFFERENTIAL_DRIVE METHODS ----
 
-	void driveStraight(double speed);
+	// Overwritten from BaseDrive.h
+	double getJoystickValue(int axisNum) override;
 
 private:
 	WPI_TalonSRX *leftTalon;
 	WPI_TalonSRX *rightTalon;
 
+	// Values specific to this class
 	double leftBias = 0.0; // Used to drive straight. Pre-defined and tested
 	double rightBias = 0.0;
 

--- a/src/driveType/PeanutChassis.h
+++ b/src/driveType/PeanutChassis.h
@@ -2,6 +2,11 @@
 #define SRC_DRIVETYPE_PEANUTCHASSIS_H_
 
 #include "BaseDrive.h"
+//#include "ctre/phoenix/MotorControl/CAN/TalonSRX.h"
+#include "ctre/Phoenix.h"
+
+
+using namespace CTRE::Phoenix::MotorControl::CAN;
 
 class PeanutChassis : public BaseDrive
 {
@@ -9,8 +14,17 @@ public:
 	PeanutChassis();
 	virtual ~PeanutChassis();
 
-private:
+	// Override DifferentialDrive methods from the base drive class
+	// ---- DIFFERENTIAL_DRIVE METHODS ----
+	void ArcadeDrive(double xSpeed, double zRotation, bool squaredInputs = true) override;
+	void CurvatureDrive(double xSpeed, double zRotation, bool isQuickTurn) override;
+	void TankDrive(double leftSpeed, double rightSpeed, bool squaredInputs = true) override;
+	// ---- END DIFFERENTIAL_DRIVE METHODS ----
 
+
+private:
+	WPI_TalonSRX *leftTalon;
+	WPI_TalonSRX *rightTalon;
 
 };
 

--- a/src/driveType/PeanutChassis.h
+++ b/src/driveType/PeanutChassis.h
@@ -21,7 +21,7 @@ public:
 	// ---- END DIFFERENTIAL_DRIVE METHODS ----
 
 	// Overwritten from BaseDrive.h
-	double getJoystickValue(int axisNum) override;
+	void driveStraight(double speed) override;
 
 private:
 	WPI_TalonSRX *leftTalon;


### PR DESCRIPTION
I've made a first-pass attempt at giving basic functionality to the Peanut Chassis and the Competition Chassis, though neither has been tested yet. I've created a very basic autonomous and teleOp routine, modeled after the working drive code created by Alex Haltom. One design change I decided to make was to remove the use of Talon and Port Mapping arrays. I believe that the Talons and Port Mappings should be contained within the specific children classes (drive types: PeanutChassis.cpp, CompChassis.cpp). This is also a much easier and less confusing alternative. Overall, I've attempted to polish the structure and organization of the drive types.